### PR TITLE
#33 Google認証後404になるバグを修正

### DIFF
--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -45,7 +45,7 @@ class Login extends Component<Props, State> {
   }
 
   login(provider: any) {
-    firebase.auth().signInWithRedirect(provider);
+    firebase.auth().signInWithPopup(provider);
   }
 
   logout() {


### PR DESCRIPTION
 認証APIをリダイレクト→ポップアップに変更することで解決
(SPAだとこうするしかないのか根本的な原因は不明)